### PR TITLE
Use bender for chainloading in bootimage

### DIFF
--- a/.config.sh
+++ b/.config.sh
@@ -1,5 +1,8 @@
 # Path to the Hedron artifact (after build)
-export HEDRON="hedron/build/src/hypervisor.elf32"
+export HEDRON="hedron/result/share/hedron/hypervisor"
+
+# Path to the Bender artifact (after build)
+export BENDER="bender/result/share/bender/bender"
 
 # "debug" or "release"
 export RELEASE=release

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "hedron"]
 	path = hedron
 	url = https://github.com/cyberus-technology/hedron.git
+[submodule "bender"]
+	path = bender
+	url = https://github.com/blitz/bender.git

--- a/README.md
+++ b/README.md
@@ -47,3 +47,12 @@ out of scope.**
 The roottask will print information to the serial device (COM1 port) but not to the VGA framebuffer. Thus, you will
 only see output from Hedron on the screen so far. Currently, there is no nice mechanism to enable the roottask to
 print to a framebuffer.
+
+### What is Bender?
+[Bender](https://github.com/blitz/bender) is a Multiboot 1 chainloader intended to be loaded from GRUB or a similar
+multiboot-capable bootloader. It tries to find PCI serial controllers and updates the
+[BIOS Data Area](https://wiki.osdev.org/BDA#BIOS_Data_Area) to make them discoverable by legacy software.
+
+I use Bender in the `gen_bootimage.sh` script because it enables to get serial output from more real devices.
+For example, some don't have an internal COM1 port anymore respectively, do not provide a physical connection to it
+anymore. A solution are PCI serial devices.

--- a/build.sh
+++ b/build.sh
@@ -12,21 +12,22 @@ cd "$DIR" || exit 1
 source .config.sh
 
 function fn_main() {
+    fn_build_bender
     fn_build_hedron
     fn_build_rust
     fn_build_rust_strip
 }
 
+function fn_build_bender() {
+    cd bender || exit 1
+    nix-build
+    cd ..
+}
+
 function fn_build_hedron() {
     cd hedron || exit 1
-    # Use toolchain provided by Nix
-    # I don't use "nix-build nix/release.nix -A hedron" here because this
-    # way is faster because Nix needs to download less stuff.
-    nix-shell --run "
-    mkdir -p build
-    cd build || exit 1
-    cmake -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ..
-    make -j 8"
+    # build without tests etc
+    nix-build nix/release.nix -A hedron.default-release
     cd ..
 }
 

--- a/gen_bootimage.sh
+++ b/gen_bootimage.sh
@@ -25,6 +25,7 @@ function fn_prepare_iso_dir() {
     mkdir -p "${ISO_SRC_DIR}/boot/grub"
 
     cp "${GRUB_DIR}/grub.cfg" "${ISO_SRC_DIR}/boot/grub/grub.cfg"
+    cp "${BENDER}" "${ISO_SRC_DIR}/bender"
     cp "${HEDRON}" "${ISO_SRC_DIR}/hedron"
     cp "${ROOTTASK}" "${ISO_SRC_DIR}/roottask"
 }

--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -4,10 +4,11 @@ set timeout=0
 set default=0
 # set debug=all
 
-# Bootstraps Hedron via Multiboot2
+# Bootstraps Hedron via Multiboot 1
 menuentry "Hedron with Minimal Roottask" {
-    # The leading slash is very important.
-    multiboot2 /hedron serial
-    module2 /roottask
+    # The leading slashes are very important.
+    multiboot /bender
+    mudule /hedron serial
+    module /roottask
     boot
 }


### PR DESCRIPTION
Bender is useful to enable PCI serial devices in legacy boot environments.

Problems:
- [ ] Currently, doesn't boot in QEMU with: `$ qemu-system-x86_64 -boot d -cdrom grub/legacy_x86_boot.img -m 2048 -cpu host -machine q35,accel=kvm:tcg -smp 2 -serial stdio --no-reboot` --> endless loop/immediate reset